### PR TITLE
Fix Build.md link

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,4 +25,4 @@ spec.dependency 'OpenCV-Dynamic-Framework'
 
 ## Reference
 
-[How to build OpenCV XCFramework](BUILD)
+[How to build OpenCV XCFramework](BUILD.md)


### PR DESCRIPTION
The broken Build.md link made me gave up on trying to build the opencv xcframework a month ago 😅 . Today luckily I clicked on Build.md file in your repo and was able to finally build it make VideoCapture work on iOS. 🙂 